### PR TITLE
Backend cleanup and npm run simplified by using flask dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ frontend/node_modules
 backend/venv
 backend/__pycache__
 backend/**/main.bundle.js
+.vscode

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,26 +1,25 @@
 import os
+import logging
 from flask import Flask, request, send_from_directory
-from livereload import Server
 from classifier import classifyImage
 from reverseProxy import proxyRequest
 
-app = Flask(__name__, static_folder="static")
-app.debug = True
+MODE = os.getenv('FLASK_ENV')
+DEV_SERVER_URL = 'http://localhost:3000'
 
-APP_PORT = 5000
-MODE = os.getenv("MODE")
-DEV_SERVER_URL = "http://localhost:3000"
+logging.getLogger('werkzeug').disabled = True
+app = Flask(__name__, static_folder='static')
 
-@app.route("/", defaults={"path": ""})
-@app.route("/<path:path>")
+@app.route('/', defaults={'path': ''})
+@app.route('/<path:path>')
 def index(path):
     # Route through webpack-dev-server if development mode.
-    if MODE == "development":
+    if MODE == 'development':
         return proxyRequest(DEV_SERVER_URL, request.path)
-    if path != "" and os.path.exists(app.static_folder + '/' + path):
+    if path and os.path.exists(app.static_folder + '/' + path):
        return send_from_directory(app.static_folder, path)
     else:
-        return send_from_directory(app.static_folder, "index.html")
+        return send_from_directory(app.static_folder, 'index.html')
 
 @app.route('/classify', methods=['GET', 'POST'])
 def classify():
@@ -30,16 +29,7 @@ def classify():
     
             result = classifyImage(file)
  
-            print("Model classification: " + result)
+            print('Model classification: ' + result)
             
             return result
     return None
-
-if __name__ == "__main__":
-    server = Server(app.wsgi_app)
-
-    # Avoid hot reload when image is received.
-    server.watch("/uploads/*", ignore=True)
-
-    # Serve app with live reload.
-    server.serve(port=APP_PORT)

--- a/backend/classifier.py
+++ b/backend/classifier.py
@@ -1,17 +1,19 @@
 import os
-import PIL
-import numpy as np
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from PIL import ImageFile
+from numpy import expand_dims
 from werkzeug.utils import secure_filename
 from tensorflow.keras.applications.imagenet_utils import preprocess_input, decode_predictions
 from tensorflow.keras.models import load_model
 from tensorflow.keras.preprocessing import image
 from tensorflow.keras.applications.resnet50 import ResNet50
 
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 model = ResNet50(weights='imagenet')
 
 def classifyImage(file):
     baseFilePath = os.path.dirname(__file__)
-    savedFilePath = os.path.join(baseFilePath, './uploads', secure_filename(file.filename))
+    savedFilePath = os.path.join(baseFilePath, r'uploads', secure_filename(file.filename))
     file.save(savedFilePath)
     
     preds = getPrediction(savedFilePath, model)
@@ -22,7 +24,7 @@ def classifyImage(file):
 def getPrediction(path, model):
     original = image.load_img(path, target_size=(224, 224))
     numpy_image = image.img_to_array(original)
-    image_batch = np.expand_dims(numpy_image, axis=0)
+    image_batch = expand_dims(numpy_image, axis=0)
 
     processed_image = preprocess_input(image_batch, mode='caffe')
     preds = model.predict(processed_image)

--- a/backend/reverseProxy.py
+++ b/backend/reverseProxy.py
@@ -5,7 +5,7 @@ from requests import get
 
 # Simple reverse proxy for use with webpack-dev-server.
 def proxyRequest(host, path):
-    response = get("%s%s"%(host, path))
+    response = get(host + path)
 
     headers = {
         name: value

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "webpack -p",
     "start": "webpack-dev-server",
-    "start:server": "cross-env MODE=development python ../backend/app.py",
-    "start:prod": "npm run build && python ../backend/app.py"
+    "start:server": "cross-env FLASK_ENV=development FLASK_APP=../backend/app.py flask run",
+    "start:prod": "npm run build && cross-env FLASK_APP=../backend/app.py flask run"
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",


### PR DESCRIPTION
- Removed main-method from app.py and updated the npm run-commands with `flask run` instead.
- Simplified some of the notations and imports to reduce memory leak.